### PR TITLE
BEC-84:Switch to Airnode promise-utils for long running async tasks i…

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as ethers from "ethers";
+import * as node from "@api3/airnode-node";
 import { Config } from "./types";
+
+export const DEFAULT_RETRY_TIMEOUT_MS = 5_000;
 
 const loadAirkeeperConfig = (): Config => {
   const configPath = path.resolve(`${__dirname}/../config/airkeeper.json`);
@@ -40,4 +43,13 @@ const printError = (error: unknown) => {
   console.log("[DEBUG]\terror message:", message);
 };
 
-export { loadAirkeeperConfig, deriveKeeperSponsorWallet, printError };
+const retryGo = <T>(
+  fn: () => Promise<T>,
+  options?: node.utils.PromiseOptions
+) =>
+  node.utils.go(
+    () => node.utils.retryOnTimeout(DEFAULT_RETRY_TIMEOUT_MS, fn),
+    options
+  );
+
+export { loadAirkeeperConfig, deriveKeeperSponsorWallet, printError, retryGo };


### PR DESCRIPTION
…n Airkeeper

Async function calls now use the go() function from promise-utils.ts. The operation that go() receives is retryable in all cases with a 5 seconds timeout.