### PR TITLE
BEC-86: Remove eventLogMaxBlocks from airkeeper.json and use blockHis…

### DIFF
--- a/config/airkeeper.json.example
+++ b/config/airkeeper.json.example
@@ -21,8 +21,7 @@
         "endpointName": "convertToUSD",
         "deviationPercentage": "5",
         "keeperSponsor": "0x2479808b1216E998309A727df8A0A98A1130A162",
-        "requestSponsor": "0x61648B2Ec3e6b3492E90184Ef281C2ba28a675ec",
-        "eventLogMaxBlocks": "10000"
+        "requestSponsor": "0x61648B2Ec3e6b3492E90184Ef281C2ba28a675ec"
       }
     ]
   }

--- a/src/start.ts
+++ b/src/start.ts
@@ -22,6 +22,7 @@ import {
 import { getGasPrice } from "./gas-prices";
 
 export const GAS_LIMIT = 500_000;
+export const BLOCK_COUNT_HISTORY_LIMIT = 300;
 
 export const handler = async (_event: any = {}): Promise<any> => {
   const startedAt = new Date();
@@ -51,6 +52,8 @@ export const handler = async (_event: any = {}): Promise<any> => {
         // 2. Initialize provider specific data
         // **************************************************************************
         console.log("[DEBUG]\tinitializing...");
+        const blockHistoryLimit =
+          chain.blockHistoryLimit || BLOCK_COUNT_HISTORY_LIMIT;
         const chainProviderUrl = chainProvider.url || "";
         const provider = node.evm.buildEVMProvider(chainProviderUrl, chain.id);
 
@@ -125,7 +128,6 @@ export const handler = async (_event: any = {}): Promise<any> => {
               endpointName,
               deviationPercentage,
               requestSponsor,
-              eventLogMaxBlocks,
             } of rrpBeaconServerKeeperJobs) {
               // **************************************************************************
               // 4. Fetch template by ID
@@ -322,7 +324,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
               ] = await retryGo(() =>
                 rrpBeaconServer.queryFilter(
                   requestedBeaconUpdateFilter,
-                  eventLogMaxBlocks * -1,
+                  blockHistoryLimit * -1,
                   currentBlock
                 )
               );
@@ -344,7 +346,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
                 await retryGo(() =>
                   rrpBeaconServer.queryFilter(
                     updatedBeaconFilter,
-                    eventLogMaxBlocks * -1,
+                    blockHistoryLimit * -1,
                     currentBlock
                   )
                 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,6 @@ export interface RrpBeaconServerKeeperTrigger {
   readonly deviationPercentage: string;
   readonly keeperSponsor: string;
   readonly requestSponsor: string;
-  readonly eventLogMaxBlocks: number;
 }
 
 export interface Config extends node.Config {


### PR DESCRIPTION
…toryLimit from config.json instead

The idea is that Airkeeper use the same number of blocks that Airnode uses when fetching history logs from chain.