### PR TITLE
BEC-118: Template information in airkeeper.json

### DIFF
--- a/config/airkeeper.json.example
+++ b/config/airkeeper.json.example
@@ -10,14 +10,14 @@
     "rrpBeaconServerKeeperJobs": [
       {
         "templateId": "0x50c604914d8ed35473149457a1a0912b785813b4e2e51bd2b75409ca25c50e1d",
-        "parameters": [
-          { "type": "bytes32", "name": "from", "value": "ETH" }
-        ],
         "templateParameters": [
           { "type": "bytes32", "name": "to", "value": "USD" },
           { "type": "bytes32", "name": "_type", "value": "int256" },
           { "type": "bytes32", "name": "_path", "value": "result" },
           { "type": "bytes32", "name": "_times", "value": "1000000" }
+        ],
+        "overrideParameters": [
+          { "type": "bytes32", "name": "from", "value": "ETH" }
         ],
         "oisTitle": "Currency Converter API",
         "endpointName": "convertToUSD",

--- a/config/airkeeper.json.example
+++ b/config/airkeeper.json.example
@@ -11,11 +11,13 @@
       {
         "templateId": "0x50c604914d8ed35473149457a1a0912b785813b4e2e51bd2b75409ca25c50e1d",
         "parameters": [
-          {
-            "type": "bytes32",
-            "name": "from",
-            "value": "ETH"
-          }
+          { "type": "bytes32", "name": "from", "value": "ETH" }
+        ],
+        "templateParameters": [
+          { "type": "bytes32", "name": "to", "value": "USD" },
+          { "type": "bytes32", "name": "_type", "value": "int256" },
+          { "type": "bytes32", "name": "_path", "value": "result" },
+          { "type": "bytes32", "name": "_times", "value": "1000000" }
         ],
         "oisTitle": "Currency Converter API",
         "endpointName": "convertToUSD",

--- a/src/start.ts
+++ b/src/start.ts
@@ -154,14 +154,14 @@ export const handler = async (_event: any = {}): Promise<any> => {
 
             for (const {
               templateId,
-              parameters,
+              overrideParameters,
               templateParameters,
               oisTitle,
               endpointName,
               deviationPercentage,
               requestSponsor,
             } of rrpBeaconServerKeeperJobs) {
-              const encodedParameters = abi.encode(parameters);
+              const encodedParameters = abi.encode(overrideParameters);
               const beaconId = ethers.utils.solidityKeccak256(
                 ["bytes32", "bytes"],
                 [templateId, encodedParameters]
@@ -229,8 +229,8 @@ export const handler = async (_event: any = {}): Promise<any> => {
                 (e) => e.name === endpointName
               )!;
               const apiCallParameters = [
-                ...parameters,
                 ...templateParameters,
+                ...overrideParameters,
               ].reduce((acc, p) => ({ ...acc, [p.name]: p.value }), {});
               const reservedParameters =
                 node.adapters.http.parameters.getReservedParameters(

--- a/src/start.ts
+++ b/src/start.ts
@@ -155,6 +155,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
             for (const {
               templateId,
               parameters,
+              templateParameters,
               oisTitle,
               endpointName,
               deviationPercentage,
@@ -188,22 +189,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
               }
 
               // **************************************************************************
-              // 4. Fetch template by ID
-              // **************************************************************************
-              node.logger.debug("fetching template...", beaconIdLogOptions);
-              const [errTemplate, template] = await retryGo(() =>
-                airnodeRrp.templates(templateId)
-              );
-              if (errTemplate || isNil(template)) {
-                node.logger.error(`template not found: ${templateId}`, {
-                  ...beaconIdLogOptions,
-                  error: errTemplate,
-                });
-                continue;
-              }
-
-              // **************************************************************************
-              // 5. Read beacon
+              // 4. Read beacon
               // **************************************************************************
               node.logger.debug("reading beacon value...", beaconIdLogOptions);
 
@@ -235,21 +221,17 @@ export const handler = async (_event: any = {}): Promise<any> => {
               );
 
               // **************************************************************************
-              // 6. Make API request
+              // 5. Make API request
               // **************************************************************************
               node.logger.debug("making API request...", beaconIdLogOptions);
               const configOis = oises.find((o) => o.title === oisTitle)!;
               const configEndpoint = configOis.endpoints.find(
                 (e) => e.name === endpointName
               )!;
-              const configParameters = parameters.reduce(
-                (acc, p) => ({ ...acc, [p.name]: p.value }),
-                {}
-              );
-              const apiCallParameters = {
-                ...node.evm.encoding.safeDecode(template.parameters),
-                ...configParameters,
-              };
+              const apiCallParameters = [
+                ...parameters,
+                ...templateParameters,
+              ].reduce((acc, p) => ({ ...acc, [p.name]: p.value }), {});
               const reservedParameters =
                 node.adapters.http.parameters.getReservedParameters(
                   configEndpoint,
@@ -267,6 +249,33 @@ export const handler = async (_event: any = {}): Promise<any> => {
                   apiCallParameters || {},
                   ois.RESERVED_PARAMETERS
                 );
+
+              // Verify templateId
+              const airnodeAddress = airnodeHDNode.derivePath(
+                ethers.utils.defaultPath
+              ).address;
+              const endpointId = ethers.utils.keccak256(
+                ethers.utils.defaultAbiCoder.encode(
+                  ["string", "string"],
+                  [oisTitle, endpointName]
+                )
+              );
+              const encodedTemplateParameters = abi.encode(templateParameters);
+              const expectedTemplateId =
+                node.evm.templates.getExpectedTemplateId({
+                  airnodeAddress,
+                  endpointId,
+                  encodedParameters: encodedTemplateParameters,
+                  id: templateId,
+                });
+              if (expectedTemplateId !== templateId) {
+                node.logger.error(
+                  `templateId '${templateId}' does not match expected templateId '${expectedTemplateId}'`,
+                  beaconIdLogOptions
+                );
+                continue;
+              }
+
               const adapterApiCredentials = apiCredentials
                 .filter((c) => c.oisTitle === oisTitle)
                 .map((c) => node.utils.removeKey(c, "oisTitle"));
@@ -324,7 +333,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
               );
 
               // **************************************************************************
-              // 7. Check deviation
+              // 6. Check deviation
               // **************************************************************************
               node.logger.debug("checking deviation...", beaconIdLogOptions);
               let beaconValue = beaconResponse.value;
@@ -351,7 +360,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
               );
 
               // **************************************************************************
-              // 8. Update beacon if necessary (call makeRequest)
+              // 7. Update beacon if necessary (call makeRequest)
               // **************************************************************************
               const percentageThreshold = basisPoints.mul(
                 Number(deviationPercentage) * 100 // support for percentages up to 2 decimal places

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface ChainConfig extends node.ChainConfig {
 export interface RrpBeaconServerKeeperTrigger {
   readonly templateId: string;
   readonly parameters: abi.InputParameter[];
+  readonly templateParameters: abi.InputParameter[];
   readonly endpointName: string;
   readonly oisTitle: string;
   readonly deviationPercentage: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,8 @@ export interface ChainConfig extends node.ChainConfig {
 
 export interface RrpBeaconServerKeeperTrigger {
   readonly templateId: string;
-  readonly parameters: abi.InputParameter[];
   readonly templateParameters: abi.InputParameter[];
+  readonly overrideParameters: abi.InputParameter[];
   readonly endpointName: string;
   readonly oisTitle: string;
   readonly deviationPercentage: string;


### PR DESCRIPTION
The main idea here is to avoid making calls to AirnodeRrp contract in order to save on blockchain provider calls. The tradeoff is that now the user of Airkeeper must also set each template parameter list in airkeeper.json config. 