### PR TITLE
BEC-137: Merge config chains object by id in Airkeeper

### DIFF
--- a/config/airkeeper.json.example
+++ b/config/airkeeper.json.example
@@ -1,6 +1,7 @@
 {
   "chains": [
     {
+      "id": "31337",
       "contracts": {
         "RrpBeaconServer": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import { Config } from "./types";
 
 export const DEFAULT_RETRY_TIMEOUT_MS = 5_000;
 
-const loadAirkeeperConfig = (): Config => {
+const parseAirkeeperConfig = (): Config => {
   const configPath = path.resolve(`${__dirname}/../config/airkeeper.json`);
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 };
@@ -45,4 +45,4 @@ const retryGo = <T>(
     options
   );
 
-export { loadAirkeeperConfig, deriveKeeperSponsorWallet, retryGo };
+export { parseAirkeeperConfig, deriveKeeperSponsorWallet, retryGo };


### PR DESCRIPTION
Now it won't matter in which order the user sets the objects inside the chains property and objects will be merged by matching it's `id` property.
I'm OK with this being a breaking change since airkeeper.json changes are not that many after this is merged.

Note: the base branch is bec136-chainds-rrpbeaconservertriggerjobs temporarily until I merge that branch to main and then I'll rebase this one onto main as well.