### PR TITLE
BEC-95: Docker build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-# Package directories
+# Package directories & files
 /node_modules
 /dist
 /lib
 /.build
 /.serverless
+*.tgz
 
 # IDE specific files
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,63 @@
-FROM node:14.17-alpine3.14
+ARG build=local
 
-LABEL application=airkeeper \
+# Environment
+FROM node:14.17-alpine3.14 AS environment
+
+ENV name="airkeeper" \
+    appDir="/app" \
+    buildDir="/build"
+ENV packageDir="${buildDir}/package"
+
+# Build preparation
+FROM environment AS preparation
+
+WORKDIR ${buildDir}
+
+RUN apk add --update --no-cache git
+
+# Source preparation - local
+FROM preparation as sourcelocal
+
+COPY . ${buildDir}
+
+# Source preparation - git
+FROM preparation as sourcegit
+
+ARG branch=main
+ARG repository=https://github.com/api3dao/airkeeper.git
+
+RUN git clone --single-branch --branch ${branch} ${repository} ${buildDir}
+
+# Production dependencies
+FROM source${build} AS deps
+
+RUN yarn install --production --no-optional --ignore-scripts
+
+FROM source${build} AS build
+
+RUN yarn install && \
+    yarn build && \
+    yarn pack && \
+    mkdir -p ${packageDir} && \
+    tar -xf *.tgz -C ${packageDir} --strip-components 1
+
+# Result image
+FROM environment
+
+WORKDIR ${appDir}
+
+LABEL application=${name} \
     description="Airkeeper lambda function"
 
-RUN apk add --update --no-cache git python3 make g++\
-    && rm -rf /var/cache/apk/*
+COPY --from=deps ${buildDir}/node_modules ./node_modules
+COPY --from=build ${packageDir} .
 
-RUN git clone --single-branch --branch main https://github.com/api3dao/airkeeper.git
+    # Create Airkeeper user
+RUN adduser -h ${appDir} -s /bin/false -S -D -H ${name} && \
+    chown -R ${name} ${appDir} && \
+    # Install serverless
+    yarn global add serverless
 
-WORKDIR /airkeeper
+USER ${name}
 
-RUN npm install
-
-CMD npm run sls:config \
-    && npm run sls:$COMMAND
+ENTRYPOINT ["sls"]

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ The `deploy` command will create a new AWS lambda function and a new AWS cloud s
 ```sh
 docker run -it --rm \
 --env-file config/aws.env \
---env COMMAND=deploy \
--v "$(pwd)/config:/airkeeper/config" \
-api3/airkeeper:latest
+-v "$(pwd)/config:/app/config" \
+api3/airkeeper:latest deploy --stage dev --region us-east-1
 ```
 
 For Windows, use CMD (and not PowerShell).
@@ -48,9 +47,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
 --env-file config/aws.env ^
---env COMMAND=deploy ^
--v "$(pwd)/config:/airkeeper/config" ^
-api3/airkeeper:latest
+-v "$(pwd)/config:/app/config" ^
+api3/airkeeper:latest deploy --stage dev --region us-east-1
 ```
 
 ### remove command
@@ -60,9 +58,8 @@ The `remove` command will delete the previously deployed AWS lambda function and
 ```sh
 docker run -it --rm \
 --env-file config/aws.env \
---env COMMAND=remove \
--v "$(pwd)/config:/airkeeper/config" \
-api3/airkeeper:latest
+-v "$(pwd)/config:/app/config" \
+api3/airkeeper:latest remove --stage dev --region us-east-1
 ```
 
 For Windows, use CMD (and not PowerShell).
@@ -70,9 +67,8 @@ For Windows, use CMD (and not PowerShell).
 ```sh
 docker run -it --rm ^
 --env-file config/aws.env ^
---env COMMAND=remove ^
--v "$(pwd)/config:/airkeeper/config" ^
-api3/airkeeper:latest
+-v "$(pwd)/config:/app/config" ^
+api3/airkeeper:latest remove --stage dev --region us-east-1
 ```
 
 ## Manual instructions

--- a/load-secrets-env.js
+++ b/load-secrets-env.js
@@ -1,11 +1,15 @@
 const dotenv = require("dotenv");
 const path = require("path");
+const fs = require("fs");
 
 module.exports = async ({ options, resolveConfigurationProperty }) => {
-  const envVars = dotenv.config({
-    // Load env vars into Serverless environment
-    path: path.resolve(`${__dirname}/config/secrets.env`),
-  }).parsed;
+  const secretsPath = path.resolve(__dirname, "config", "secrets.env");
+  const envVars = fs.existsSync(secretsPath)
+    ? dotenv.config({
+        // Load env vars into Serverless environment
+        path: secretsPath,
+      }).parsed
+    : {};
   // Return all env vars that don't start with "AWS_"
   return Object.keys(envVars)
     .filter((key) => !key.startsWith("AWS_"))

--- a/package.json
+++ b/package.json
@@ -3,13 +3,21 @@
   "license": "MIT",
   "version": "1.0.0",
   "description": "A tool to update a beacon server value on a time interval",
-  "main": "index.js",
+  "main": "./dist/src/start.js",
+  "files": [
+    "dist",
+    "serverless.yml",
+    "*.js"
+  ],
   "scripts": {
+    "build": "yarn clean && yarn compile",
+    "clean": "rimraf -rf ./dist *.tgz",
+    "compile": "tsc -p tsconfig.json",
     "sls:config": "sls config credentials --provider aws --key $AWS_ACCESS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY",
-    "sls:deploy": "sls deploy --region $REGION --stage $STAGE",
+    "sls:deploy": "yarn build && sls deploy --region $REGION --stage $STAGE",
     "sls:remove": "sls remove --region $REGION --stage $STAGE",
     "sls:invoke": "sls invoke --function start",
-    "sls:invoke-local": "sls invoke local --function start"
+    "sls:invoke-local": "yarn build && sls invoke local --function start"
   },
   "dependencies": {
     "@api3/airnode-abi": "^0.3.1",
@@ -28,7 +36,6 @@
     "@types/serverless": "^1.78.39",
     "rimraf": "^3.0.2",
     "serverless": "^2.68.0",
-    "serverless-plugin-typescript": "^2.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.2"
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,8 +1,5 @@
 service: airkeeper
 
-plugins:
-  - serverless-plugin-typescript
-
 variablesResolutionMode: 20210326
 
 provider:
@@ -21,7 +18,7 @@ package:
 
 functions:
   start:
-    handler: src/start.handler
+    handler: dist/src/start.handler
     name: airkeeper-update-beacon
     timeout: 60
     events:

--- a/src/start.ts
+++ b/src/start.ts
@@ -29,7 +29,7 @@ export const handler = async (_event: any = {}): Promise<any> => {
   // 1. Load config
   // **************************************************************************
   // This file must be the same as the one used by the node
-  const nodeConfigPath = path.resolve(`${__dirname}/../config/config.json`);
+  const nodeConfigPath = path.resolve(`${__dirname}/../../config/config.json`);
   const nodeConfig = node.config.parseConfig(nodeConfigPath, process.env);
   // This file will be merged with config.json from node
   const keeperConfig = parseAirkeeperConfig();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import { Config } from "./types";
 export const DEFAULT_RETRY_TIMEOUT_MS = 5_000;
 
 const parseAirkeeperConfig = (): Config => {
-  const configPath = path.resolve(`${__dirname}/../config/airkeeper.json`);
+  const configPath = path.resolve(`${__dirname}/../../config/airkeeper.json`);
   return JSON.parse(fs.readFileSync(configPath, "utf8"));
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/src",
     "target": "esnext",
     "module": "commonjs",
     "lib": ["esnext"],


### PR DESCRIPTION
Changes made:
* Removed `serverless-plugin-typescript` plugin as its usage in the container made the container slower and bigger. I'm instead building the sources manually.
* There is no need for `sls config credentials` in the container if you make the credentials available in standard places (either config file or env variables)