### PR TITLE
Removed mnemonic dependency

### DIFF
--- a/config/airkeeper.example.json
+++ b/config/airkeeper.example.json
@@ -1,4 +1,6 @@
 {
+  "airnode": "0x15391C3E06Db67FD72bd80747D131d514E1EA674",
+  "airnodeXpub": "xpub6CjvSJ3sybHuVaYnQsCvNQnXfNrMusXEtfoAvYuS1pEDtKngXQE1dcTDXR9dgwfqdakksFrhNHeKiqsYKD6KS5mga1NvegzbV6nKwsNyfGd",
   "chains": [
     {
       "id": "31337",

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface RrpBeaconServerKeeperTrigger {
 }
 
 export interface Config extends node.Config {
+  readonly airnode: string;
+  readonly airnodeXpub: string;
   readonly chains: ChainConfig[];
   readonly triggers: node.Triggers & {
     rrpBeaconServerKeeperJobs: RrpBeaconServerKeeperTrigger[];


### PR DESCRIPTION
I've added `airnode` and `airnodeXpub` to the `airkeeper.json`. I've placed them on the root of the json because airkeeper is designed to be used with only one airnode. Also adjusted the types but not entirely sure if it was the correct way of doing it.