### PR TITLE
Retrygo refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@api3/airnode-node": "^0.4.1",
     "@api3/airnode-ois": "^0.4.1",
     "@api3/airnode-protocol": "^0.4.1",
+    "@api3/promise-utils": "^0.1.0",
     "dotenv-safe": "^8.2.0",
     "ethers": "^5.5.2",
     "lodash": "^4.17.21"

--- a/src/api/call-api.test.ts
+++ b/src/api/call-api.test.ts
@@ -136,9 +136,7 @@ describe('callApi', () => {
     const spy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
 
     const apiResponse = { success: true, result: '723.392028' };
-    spy.mockResolvedValueOnce({
-      ...apiResponse,
-    });
+    spy.mockResolvedValueOnce(apiResponse);
 
     const [logs, res] = await callApi(callApiOptions);
 
@@ -245,9 +243,7 @@ describe('callApi', () => {
   it('returns an error if the API call fails to extract and encode response', async () => {
     const buildAndExecuteRequestSpy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
     const apiResponse = { success: true, result: '723.392028' };
-    buildAndExecuteRequestSpy.mockResolvedValueOnce({
-      ...apiResponse,
-    });
+    buildAndExecuteRequestSpy.mockResolvedValueOnce(apiResponse);
 
     const extractAndEncodeResponseSpy = jest.spyOn(adapter, 'extractAndEncodeResponse');
     const error = new Error('Unexpected error');

--- a/src/api/call-api.test.ts
+++ b/src/api/call-api.test.ts
@@ -137,7 +137,7 @@ describe('callApi', () => {
 
     const apiResponse = { success: true, result: '723.392028' };
     spy.mockResolvedValueOnce({
-      data: apiResponse,
+      ...apiResponse,
     });
 
     const [logs, res] = await callApi(callApiOptions);
@@ -246,7 +246,7 @@ describe('callApi', () => {
     const buildAndExecuteRequestSpy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
     const apiResponse = { success: true, result: '723.392028' };
     buildAndExecuteRequestSpy.mockResolvedValueOnce({
-      data: apiResponse,
+      ...apiResponse,
     });
 
     const extractAndEncodeResponseSpy = jest.spyOn(adapter, 'extractAndEncodeResponse');

--- a/src/evm/initialize-provider.ts
+++ b/src/evm/initialize-provider.ts
@@ -43,7 +43,7 @@ export const initializeProvider = async (
     return [[log], null];
   }
   const currentBlockMessage = `Current block number for chainId ${chain.id}: ${currentBlock.data}`;
-  const currentBlockLog = node.logger.pend('DEBUG', currentBlockMessage);
+  const currentBlockLog = node.logger.pend('INFO', currentBlockMessage);
 
   // Fetch current gas fee data
   const [gasPriceLogs, gasTarget] = await node.evm.getGasPrice({

--- a/src/evm/initialize-provider.ts
+++ b/src/evm/initialize-provider.ts
@@ -1,9 +1,10 @@
 import * as node from '@api3/airnode-node';
 import * as protocol from '@api3/airnode-protocol';
+import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import isNil from 'lodash/isNil';
 import { ChainConfig, EVMProviderState } from '../types';
-import { retryGo } from '../utils';
+import { DEFAULT_RETRY_TIMEOUT_MS } from '../constants';
 
 const rrpBeaconServerAbi = new ethers.utils.Interface(protocol.RrpBeaconServerFactory.abi).format(
   ethers.utils.FormatTypes.minimal
@@ -35,13 +36,13 @@ export const initializeProvider = async (
   const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
 
   // Fetch current block number
-  const [errorGetBlockNumber, currentBlock] = await retryGo(() => provider.getBlockNumber());
-  if (errorGetBlockNumber || isNil(currentBlock)) {
+  const currentBlock = await go(() => provider.getBlockNumber(), { timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
+  if (!currentBlock.success) {
     const message = 'Failed to fetch the blockNumber';
-    const log = node.logger.pend('ERROR', message, errorGetBlockNumber);
+    const log = node.logger.pend('ERROR', message, currentBlock.error);
     return [[log], null];
   }
-  const currentBlockMessage = `Current block number for chainId ${chain.id}: ${currentBlock}`;
+  const currentBlockMessage = `Current block number for chainId ${chain.id}: ${currentBlock.data}`;
   const currentBlockLog = node.logger.pend('DEBUG', currentBlockMessage);
 
   // Fetch current gas fee data
@@ -63,7 +64,7 @@ export const initializeProvider = async (
       provider,
       contracts,
       voidSigner,
-      currentBlock,
+      currentBlock: currentBlock.data,
       gasTarget,
     },
   ];

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -1,5 +1,6 @@
 import * as abi from '@api3/airnode-abi';
 import * as node from '@api3/airnode-node';
+import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import { Dictionary } from 'lodash';
 import flatMap from 'lodash/flatMap';
@@ -26,7 +27,7 @@ import {
   State,
   Subscription,
 } from '../types';
-import { retryGo } from '../utils';
+import { DEFAULT_RETRY_TIMEOUT_MS } from '../constants';
 
 export const handler = async (_event: any = {}): Promise<any> => {
   const startedAt = new Date();
@@ -166,20 +167,22 @@ const executeApiCalls = async (state: State): Promise<State> => {
       },
     };
     const apiCallParameters = abi.decode(template.templateParameters);
-    const [errorCallApi, logsData] = await retryGo(() =>
-      callApi({
-        oises: config.ois,
-        apiCredentials: config.apiCredentials,
-        apiCallParameters,
-        oisTitle: endpoint.oisTitle,
-        endpointName: endpoint.endpointName,
-      })
+    const logsData = await go(
+      () =>
+        callApi({
+          oises: config.ois,
+          apiCredentials: config.apiCredentials,
+          apiCallParameters,
+          oisTitle: endpoint.oisTitle,
+          endpointName: endpoint.endpointName,
+        }),
+      { timeoutMs: DEFAULT_RETRY_TIMEOUT_MS }
     );
-    if (!isNil(errorCallApi) || isNil(logsData)) {
+    if (!logsData.success) {
       node.logger.warn('Failed to fecth API value', templateLogOptions);
       continue;
     }
-    const [logs, apiValue] = logsData;
+    const [logs, apiValue] = logsData.data;
     node.logger.logPending(logs, templateLogOptions);
 
     if (isNil(apiValue)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,0 @@
-import * as node from '@api3/airnode-node';
-import { DEFAULT_RETRY_TIMEOUT_MS } from './constants';
-
-const retryGo = <T>(fn: () => Promise<T>, options?: node.utils.PromiseOptions) =>
-  node.utils.go(() => node.utils.retryOnTimeout(DEFAULT_RETRY_TIMEOUT_MS, fn), options);
-
-export { retryGo };

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,13 @@
     lodash "^4.17.21"
     yargs "^17.1.0"
 
+"@api3/promise-utils@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@api3/promise-utils/-/promise-utils-0.1.0.tgz#bc0678a5d19b32274192656dc787a131e22d82dc"
+  integrity sha512-hel2yq9p9d5Yki9nf+9S7XNDzko+FVzYUps5JGwl6XvV5eBaEUDkEeTG5ulyUORzJdplfT+KyE1zxwIMG/ZfhQ==
+  dependencies:
+    "@lifeomic/attempt" "^3.0.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -956,7 +963,7 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@lifeomic/attempt@^3.0.0":
+"@lifeomic/attempt@^3.0.0", "@lifeomic/attempt@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.2.tgz#6920d6fa76e911c2d27e5a7c9a5f42aff2292733"
   integrity sha512-JHRfM7fUit2UroC0xRnuzMGegSTbfvz6X/1PgcIvahXC+A7UsKa8XfR1YrBsvoSu669iMTeNkDb26pSkGOzXKw==


### PR DESCRIPTION
This replaces the `retryGo` function with `go` from [promise-utils](https://github.com/api3dao/promise-utils) and updates the code to use the new `GoResult` return value instead of the tuple form.

