### PR TITLE
Add all-tests-passed and docker image builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
       - main
     types: [opened, synchronize, reopened]
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   documentation:
     name: Check documentation
@@ -53,3 +56,39 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test
+  docker-build:
+    name: Build docker image and push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Airkeeper
+        uses: actions/checkout@v2
+      - name: Build Airkeeper docker image
+        run: |
+          docker build -t api3/airkeeper-dev:${{ github.sha }} .
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push Airkeeper image to Docker Hub
+        run: |
+          docker push api3/airkeeper-dev:${{ github.sha }}
+  build-complete:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [documentation, docker-build, unit-tests]
+    steps:
+      - run: exit 0
+      - name: Slack Notification
+        uses: lazy-actions/slatify@master
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # env.SLACK_WEBHOOK_URL != null is a workaround dependabot not having access to secrets
+        if: ${{ always() && env.SLACK_WEBHOOK_URL != null }}
+        with:
+          channel: '#technical-notifications'
+          commit: true
+          job_name: 'Airkeeper - Continuous Build'
+          token: ${{ secrets.ACCESS_TOKEN }}
+          type: ${{ job.status }}
+          url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
It seems that having an "All tests passed" step is required to allow Github require CI status checks for PRs.
I added Docker builds while I was at it.