### PR TITLE
Refactor forEach to reduce

### DIFF
--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -299,7 +299,7 @@ const groupSubscriptionsBySponsorWallet = async (
   );
   const sponsorWalletsAndTransactionCounts = await Promise.all(sponsorWalletAndTransactionCountPromises);
   const sponsorWalletsWithSubscriptions = sponsorWalletsAndTransactionCounts.reduce(
-    (acc: SponsorWalletWithSubscriptions[], [logs, data]) => {
+    (acc: SponsorWalletWithSubscriptions[], [logs, data], idx) => {
       const sponsorLogOptions: node.LogOptions = {
         ...providerLogOptions,
         additional: {
@@ -314,13 +314,12 @@ const groupSubscriptionsBySponsorWallet = async (
         return acc;
       }
 
-      let nextNonce = data.transactionCount;
       return [
         ...acc,
         {
           subscriptions: subscriptionsBySponsor[data.sponsor].map((subscription) => ({
             ...subscription,
-            nonce: nextNonce++,
+            nonce: data.transactionCount + idx + 1,
           })),
           sponsorWallet: data.sponsorWallet,
         },


### PR DESCRIPTION
Refactors `validSubscriptions` and `sponsorWalletsWithSubscriptions` to use `reduce`.
Updated to also refactor:  `enabledSubscriptions` and `groupedSubscriptions`.

~~Note: `enabledSubscriptions` and `groupedSubscriptions` are covered here: #32. I'm opening this so I can move on to other work but this PR can be closed if these are also to be covered in #32.~~