### PR TITLE
Fix derivation of subscriptionId

### DIFF
--- a/scripts/psp-beacon-local-setup.js
+++ b/scripts/psp-beacon-local-setup.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const ethers = require('ethers');
 const abi = require('@api3/airnode-abi');
+const { keccak256 } = require('ethers/lib/utils');
 const { deriveSponsorWallet } = require('../dist/src/wallet.js');
 
 async function main() {
@@ -104,8 +105,8 @@ async function main() {
       airnodeWallet.address,
       roles.sponsor.address
     );
-  const beaconUpdateSubscriptionId = ethers.utils.keccak256(
-    ethers.utils.solidityPack(
+  const beaconUpdateSubscriptionId = keccak256(
+    ethers.utils.defaultAbiCoder.encode(
       ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
       [
         (await provider.getNetwork()).chainId,

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -5,6 +5,7 @@ import { Dictionary } from 'lodash';
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
+import { keccak256 } from 'ethers/lib/utils';
 import { callApi } from '../api/call-api';
 import { loadAirkeeperConfig, loadAirnodeConfig, mergeConfigs } from '../config';
 import { checkSubscriptionCondition } from '../evm/check-conditions';
@@ -65,19 +66,22 @@ const initializeState = (config: Config): State => {
       return acc;
     }
     // Verify subscriptionId
-    const expectedSubscriptionId = ethers.utils.solidityKeccak256(
-      ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
-      [
-        subscription.chainId,
-        subscription.airnodeAddress,
-        subscription.templateId,
-        subscription.parameters,
-        subscription.conditions,
-        subscription.relayer,
-        subscription.sponsor,
-        subscription.requester,
-        subscription.fulfillFunctionId,
-      ]
+    // Verify subscriptionId
+    const expectedSubscriptionId = keccak256(
+      ethers.utils.defaultAbiCoder.encode(
+        ['uint256', 'address', 'bytes32', 'bytes', 'bytes', 'address', 'address', 'address', 'bytes4'],
+        [
+          subscription.chainId,
+          subscription.airnodeAddress,
+          subscription.templateId,
+          subscription.parameters,
+          subscription.conditions,
+          subscription.relayer,
+          subscription.sponsor,
+          subscription.requester,
+          subscription.fulfillFunctionId,
+        ]
+      )
     );
     if (subscriptionId !== expectedSubscriptionId) {
       node.logger.warn(


### PR DESCRIPTION
I discovered through a chat with Burak this morning that the subscription Id was being incorrectly derived, probably due to the Trail-of-Bits-related change (packing).

The related contract code is here: https://github.com/api3dao/airnode/blob/fb7968b0bd38a3ba85f6c2af5bae779a0b0df7a4/packages/airnode-protocol-v1/contracts/dapis/DapiServer.sol#L269