### PR TITLE
Bec214 airkeeper unit tests

### DIFF
--- a/src/evm/check-conditions.test.ts
+++ b/src/evm/check-conditions.test.ts
@@ -1,0 +1,108 @@
+import { ethers } from 'ethers';
+import { checkSubscriptionCondition } from './check-conditions';
+import { dapiServerAbi } from './initialize-provider';
+import * as utils from '../utils';
+
+describe('checkSubscriptionCondition', () => {
+  beforeEach(() => jest.restoreAllMocks());
+
+  const subscription = {
+    chainId: '31337',
+    airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+    parameters: '0x',
+    conditions:
+      '0x31624200000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e46756e6374696f6e4964000000000000000000000000dc96acc8000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e506172616d657465727300000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000989680',
+    relayer: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    sponsor: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    requester: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    fulfillFunctionId: '0x206b48f4',
+    id: '0x168194af62ab1b621eff3be1df9646f198dcef36f9eace0474fd19d47b2e0039',
+  };
+  const apiValue = ethers.BigNumber.from(723392020);
+  const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545/');
+  const dapiServer = new ethers.Contract('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', dapiServerAbi, provider);
+  const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
+
+  it('should return true if subscription conditions check passes', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest.spyOn(utils, 'retryGo').mockResolvedValueOnce([null, [true]]);
+
+    const [logs, data] = await checkSubscriptionCondition(subscription, apiValue, dapiServer, voidSigner);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([]);
+    expect(data).toEqual(true);
+  });
+
+  it('should return false if subscription conditions check does not passes', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest.spyOn(utils, 'retryGo').mockResolvedValueOnce([null, [false]]);
+
+    const [logs, data] = await checkSubscriptionCondition(subscription, apiValue, dapiServer, voidSigner);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([
+      {
+        level: 'WARN',
+        message: 'Conditions not met. Skipping update...',
+      },
+    ]);
+    expect(data).toEqual(false);
+  });
+
+  it('returns false with error log if conditions decode fails', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest.spyOn(utils, 'retryGo').mockResolvedValueOnce([null, [true]]);
+
+    const [logs, data] = await checkSubscriptionCondition(
+      { ...subscription, conditions: '0xinvalid' },
+      apiValue,
+      dapiServer,
+      voidSigner
+    );
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(0);
+    expect(logs).toEqual([
+      {
+        error: expect.objectContaining({ message: expect.stringContaining('invalid arrayify value') }),
+        level: 'ERROR',
+        message: 'Failed to decode conditions',
+      },
+    ]);
+    expect(data).toEqual(false);
+  });
+
+  it('returns false with error log if condition function returns an error', async () => {
+    const unexpectedError = new Error('Something when wrong');
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest.spyOn(utils, 'retryGo').mockResolvedValueOnce([unexpectedError, null]);
+
+    const [logs, data] = await checkSubscriptionCondition(subscription, apiValue, dapiServer, voidSigner);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([
+      {
+        error: unexpectedError,
+        level: 'ERROR',
+        message: 'Failed to check conditions',
+      },
+    ]);
+    expect(data).toEqual(false);
+  });
+  it('returns false with error log if conditions result is null', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest.spyOn(utils, 'retryGo').mockResolvedValueOnce([null, null]);
+
+    const [logs, data] = await checkSubscriptionCondition(subscription, apiValue, dapiServer, voidSigner);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([
+      {
+        level: 'ERROR',
+        message: 'Failed to check conditions',
+      },
+    ]);
+    expect(data).toEqual(false);
+  });
+});

--- a/src/evm/check-conditions.test.ts
+++ b/src/evm/check-conditions.test.ts
@@ -47,8 +47,13 @@ describe('checkSubscriptionCondition', () => {
   it('should return true if subscription conditions check passes', async () => {
     const [logs, data] = await checkSubscriptionCondition(subscription, apiValue, dapiServerMock as any, voidSigner);
 
-    expect(getFunctionSpy).toHaveBeenCalledTimes(1);
-    expect(conditionPspBeaconUpdateSpy).toHaveBeenCalledTimes(1);
+    expect(getFunctionSpy).toHaveBeenNthCalledWith(1, '0xdc96acc8');
+    expect(conditionPspBeaconUpdateSpy).toHaveBeenNthCalledWith(
+      1,
+      subscription.id,
+      '0x000000000000000000000000000000000000000000000000000000002b1e1614',
+      '0x0000000000000000000000000000000000000000000000000000000000989680'
+    );
     expect(logs).toEqual([]);
     expect(data).toEqual(true);
   });
@@ -165,11 +170,11 @@ describe('checkSubscriptionCondition', () => {
     expect(data).toEqual(false);
   });
 
-  it('returns false with error log if conditions result is null', async () => {
+  it('returns false with warn log if conditions result is undefined', async () => {
     const conditionPspBeaconUpdateNullSpy = jest
       .fn()
       .mockImplementation((_subscriptionId: string, _encodedFulfillmentData: string, _conditionParameters: string) =>
-        Promise.resolve(null)
+        Promise.resolve(undefined)
       );
     const [logs, data] = await checkSubscriptionCondition(
       subscription,
@@ -188,8 +193,8 @@ describe('checkSubscriptionCondition', () => {
     expect(conditionPspBeaconUpdateNullSpy).toHaveBeenCalledTimes(1);
     expect(logs).toEqual([
       {
-        level: 'ERROR',
-        message: 'Failed to check conditions',
+        level: 'WARN',
+        message: 'Conditions not met. Skipping update...',
       },
     ]);
     expect(data).toEqual(false);

--- a/src/evm/check-conditions.ts
+++ b/src/evm/check-conditions.ts
@@ -41,7 +41,7 @@ export const checkSubscriptionCondition = async (
 
   // TODO: Should we also include the condition contract address to be called in subscription.conditions
   //       and connect to that contract instead of dapiServer contract to call the conditionFunction?
-  const result = await go(
+  const result = await go<ethers.utils.Result, Error>(
     () =>
       contract
         .connect(voidSigner)
@@ -58,7 +58,7 @@ export const checkSubscriptionCondition = async (
   // The result will always be ethers.Result type even if solidity function retuns a single value
   // because we are not calling contract.METHOD_NAME but contract.functions.METHOD_NAME instead
   // See https://docs.ethers.io/v5/api/contract/contract/#Contract-functionsCall
-  if (!result.data[0]) {
+  if (!result.data || !result.data[0]) {
     const message = 'Conditions not met. Skipping update...';
     const log = node.logger.pend('WARN', message);
     return [[log], false];

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -1,0 +1,4 @@
+export * from './initialize-provider';
+export * from './check-conditions';
+export * from './transaction-count';
+export * from './process-sponsor-wallet';

--- a/src/evm/initialize-provider.test.ts
+++ b/src/evm/initialize-provider.test.ts
@@ -1,0 +1,123 @@
+import { ethers } from 'ethers';
+import { initializeProvider } from './initialize-provider';
+import { BASE_FEE_MULTIPLIER, PRIORITY_FEE_IN_WEI } from '../constants';
+import { ChainConfig } from '../types';
+
+describe('initializeProvider', () => {
+  beforeEach(() => jest.restoreAllMocks());
+
+  const chain: ChainConfig = {
+    maxConcurrency: 100,
+    authorizers: [],
+    contracts: {
+      AirnodeRrp: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      RrpBeaconServer: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
+      DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    },
+    id: '31337',
+    providers: { local: { url: 'http://127.0.0.1:8545' } },
+    type: 'evm',
+    options: {
+      txType: 'eip1559',
+      baseFeeMultiplier: '2',
+      priorityFee: { value: '3.12', unit: 'gwei' },
+    },
+  };
+  const providerUrl = 'http://localhost:8545';
+
+  it('should initialize provider', async () => {
+    const getBlockNumberSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlockNumber');
+    const currentBlock = Math.floor(Date.now() / 1000);
+    getBlockNumberSpy.mockResolvedValueOnce(currentBlock);
+
+    const { gasTarget, blockSpy, gasPriceSpy } = createAndMockGasTarget('eip1559');
+
+    const [logs, data] = await initializeProvider(chain, providerUrl);
+
+    expect(getBlockNumberSpy).toHaveBeenCalled();
+    expect(blockSpy).toHaveBeenCalled();
+    expect(gasPriceSpy).not.toHaveBeenCalled();
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        { level: 'INFO', message: `Current block number for chainId 31337: ${currentBlock}` },
+        {
+          level: 'INFO',
+          message: `Gas target for chainId 31337: ${JSON.stringify(gasTarget)}`,
+        },
+      ])
+    );
+    expect(data).toEqual(
+      expect.objectContaining({
+        provider: expect.any(ethers.providers.JsonRpcProvider),
+        contracts: expect.objectContaining({
+          RrpBeaconServer: expect.any(ethers.Contract),
+          DapiServer: expect.any(ethers.Contract),
+        }),
+        voidSigner: expect.any(ethers.VoidSigner),
+        currentBlock,
+        gasTarget,
+      })
+    );
+  });
+
+  it('returns null with error log if current block cannot be fetched', async () => {
+    const getBlockNumberSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlockNumber');
+    const errorMessage = 'could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.5.3)';
+    getBlockNumberSpy.mockRejectedValueOnce(new Error(errorMessage));
+
+    const { blockSpy, gasPriceSpy } = createAndMockGasTarget('eip1559');
+
+    const [logs, data] = await initializeProvider(chain, providerUrl);
+
+    expect(blockSpy).not.toHaveBeenCalled();
+    expect(gasPriceSpy).not.toHaveBeenCalled();
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          error: expect.objectContaining({ message: expect.stringContaining('could not detect network') }),
+          level: 'ERROR',
+          message: 'Failed to fetch the blockNumber',
+        }),
+      ])
+    );
+    expect(data).toEqual(null);
+  });
+
+  it('returns null with error log if gas target cannot be fetched', async () => {
+    const getBlockNumberSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlockNumber');
+    const currentBlock = Math.floor(Date.now() / 1000);
+    getBlockNumberSpy.mockResolvedValueOnce(currentBlock);
+
+    const gasPriceSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getGasPrice');
+    const errorMessage = 'could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.5.3)';
+    gasPriceSpy.mockRejectedValueOnce(new Error(errorMessage));
+    const blockSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlock');
+    blockSpy.mockRejectedValueOnce(new Error(errorMessage));
+
+    const [logs, data] = await initializeProvider(chain, providerUrl);
+
+    expect(getBlockNumberSpy).toHaveBeenCalled();
+    expect(logs).toEqual(expect.arrayContaining([{ level: 'ERROR', message: 'Failed to fetch gas price' }]));
+    expect(data).toEqual(null);
+  });
+});
+
+/**
+ * Creates and mocks gas pricing-related resources based on txType.
+ */
+const createAndMockGasTarget = (txType: 'legacy' | 'eip1559') => {
+  const gasPriceSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getGasPrice');
+  const blockSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlock');
+  if (txType === 'legacy') {
+    const gasPrice = ethers.BigNumber.from(1000);
+    gasPriceSpy.mockResolvedValue(gasPrice);
+    return { gasTarget: { gasPrice }, blockSpy, gasPriceSpy };
+  }
+
+  const baseFeePerGas = ethers.BigNumber.from(1000);
+  blockSpy.mockResolvedValue({ baseFeePerGas } as ethers.providers.Block);
+  const maxPriorityFeePerGas = ethers.BigNumber.from(PRIORITY_FEE_IN_WEI);
+  const maxFeePerGas = baseFeePerGas.mul(BASE_FEE_MULTIPLIER).add(maxPriorityFeePerGas);
+
+  return { gasTarget: { maxPriorityFeePerGas, maxFeePerGas }, blockSpy, gasPriceSpy };
+};

--- a/src/evm/initialize-provider.test.ts
+++ b/src/evm/initialize-provider.test.ts
@@ -6,6 +6,8 @@ import { ChainConfig } from '../types';
 describe('initializeProvider', () => {
   beforeEach(() => jest.restoreAllMocks());
 
+  const providerUrl = 'http://localhost:8545';
+
   const chain: ChainConfig = {
     maxConcurrency: 100,
     authorizers: [],
@@ -15,7 +17,7 @@ describe('initializeProvider', () => {
       DapiServer: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
     },
     id: '31337',
-    providers: { local: { url: 'http://127.0.0.1:8545' } },
+    providers: { local: { url: providerUrl } },
     type: 'evm',
     options: {
       txType: 'eip1559',
@@ -23,20 +25,29 @@ describe('initializeProvider', () => {
       priorityFee: { value: '3.12', unit: 'gwei' },
     },
   };
-  const providerUrl = 'http://localhost:8545';
 
-  it('should initialize provider', async () => {
+  test.each(['legacy', 'eip1559'] as const)('should initialize provider - txType: %s', async (txType) => {
     const getBlockNumberSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getBlockNumber');
     const currentBlock = Math.floor(Date.now() / 1000);
     getBlockNumberSpy.mockResolvedValueOnce(currentBlock);
 
-    const { gasTarget, blockSpy, gasPriceSpy } = createAndMockGasTarget('eip1559');
+    const { gasTarget, blockSpy, gasPriceSpy } = createAndMockGasTarget(txType);
 
-    const [logs, data] = await initializeProvider(chain, providerUrl);
+    const [logs, data] = await initializeProvider(
+      {
+        ...chain,
+        options: {
+          txType,
+          baseFeeMultiplier: '2',
+          priorityFee: { value: '3.12', unit: 'gwei' },
+        },
+      },
+      providerUrl
+    );
 
     expect(getBlockNumberSpy).toHaveBeenCalled();
-    expect(blockSpy).toHaveBeenCalled();
-    expect(gasPriceSpy).not.toHaveBeenCalled();
+    expect(txType === 'legacy' ? blockSpy : gasPriceSpy).not.toHaveBeenCalled();
+    expect(txType === 'eip1559' ? blockSpy : gasPriceSpy).toHaveBeenCalled();
     expect(logs).toEqual(
       expect.arrayContaining([
         { level: 'INFO', message: `Current block number for chainId 31337: ${currentBlock}` },

--- a/src/evm/process-sponsor-wallet.test.ts
+++ b/src/evm/process-sponsor-wallet.test.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import { processSponsorWallet } from './process-sponsor-wallet';
 import { deriveSponsorWallet } from '../wallet';
+import { GAS_LIMIT } from '../constants';
 
 describe('processSponsorWallet', () => {
   beforeEach(() => jest.restoreAllMocks());
@@ -101,8 +102,19 @@ describe('processSponsorWallet', () => {
       sponsorWallet
     );
 
-    expect(getFunctionSpy).toHaveBeenCalledTimes(3);
-    expect(fulfillPspBeaconUpdateSpy).toHaveBeenCalledTimes(3);
+    expect(getFunctionSpy).toHaveBeenNthCalledWith(2, '0x206b48f4');
+    subscriptions.forEach((subscription, idx) =>
+      expect(fulfillPspBeaconUpdateSpy).toHaveBeenCalledWith(
+        subscription.id,
+        subscription.airnodeAddress,
+        subscription.relayer,
+        subscription.sponsor,
+        expect.anything(), // timestamp
+        ethers.utils.defaultAbiCoder.encode(['int256'], [subscription.apiValue]),
+        expect.any(String), // signature
+        { gasLimit: GAS_LIMIT, ...gasTarget, nonce: idx }
+      )
+    );
     expect(logsData).toEqual(
       expect.arrayContaining([
         [

--- a/src/evm/process-sponsor-wallet.test.ts
+++ b/src/evm/process-sponsor-wallet.test.ts
@@ -1,0 +1,207 @@
+import { ethers } from 'ethers';
+import { dapiServerAbi } from './initialize-provider';
+import { processSponsorWallet } from './process-sponsor-wallet';
+import { deriveSponsorWallet } from '../wallet';
+import * as utils from '../utils';
+
+describe('processSponsorWallet', () => {
+  beforeEach(() => jest.restoreAllMocks());
+
+  const airnodeWallet = ethers.Wallet.fromMnemonic(
+    'achieve climb couple wait accident symbol spy blouse reduce foil echo label'
+  );
+  const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545/');
+  const dapiServer = new ethers.Contract('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0', dapiServerAbi, provider);
+  const gasTarget = {
+    maxPriorityFeePerGas: ethers.BigNumber.from(3120000000),
+    maxFeePerGas: ethers.BigNumber.from(3866792752),
+  };
+  const subscription1 = {
+    chainId: '31337',
+    airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+    parameters: '0x',
+    conditions:
+      '0x31624200000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e46756e6374696f6e4964000000000000000000000000dc96acc8000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e506172616d657465727300000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000989680',
+    relayer: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    sponsor: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    requester: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    fulfillFunctionId: '0x206b48f4',
+    id: '0x168194af62ab1b621eff3be1df9646f198dcef36f9eace0474fd19d47b2e0039',
+    apiValue: ethers.BigNumber.from(723392020),
+    nonce: 0,
+  };
+  const subscription2 = {
+    chainId: '31337',
+    airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    templateId: '0xea30f92923ece1a97af69d450a8418db31be5a26a886540a13c09c739ba8eaaa',
+    parameters: '0x',
+    conditions:
+      '0x31624200000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e46756e6374696f6e4964000000000000000000000000dc96acc8000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e506172616d657465727300000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000001312d00',
+    relayer: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    sponsor: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    requester: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    fulfillFunctionId: '0x206b48f4',
+    id: '0x6efac1aca63fe97cbb96498d49e600397eb118956bc84a600e08f6eaa95a882e',
+    apiValue: ethers.BigNumber.from(723392020),
+    nonce: 1,
+  };
+  const subscription3 = {
+    chainId: '31337',
+    airnodeAddress: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    templateId: '0x0bbf5f2ec4b0e9faf5b89b4ddbed9bdad7a542cc258ffd7b106b523aeae039a6',
+    parameters: '0x',
+    conditions:
+      '0x31624200000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e46756e6374696f6e4964000000000000000000000000dc96acc8000000000000000000000000000000000000000000000000000000005f636f6e646974696f6e506172616d657465727300000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000989680',
+    relayer: '0xA30CA71Ba54E83127214D3271aEA8F5D6bD4Dace',
+    sponsor: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    requester: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+    fulfillFunctionId: '0x206b48f4',
+    id: '0xb8bf267396f5acdb28a2b50da3a236c0e29db1e222df25d12a50f68cb55d4f71',
+    apiValue: ethers.BigNumber.from(46640440000),
+    nonce: 2,
+  };
+  const subscriptions = [subscription1, subscription2, subscription3];
+  const sponsorWallet = deriveSponsorWallet(
+    airnodeWallet.mnemonic.phrase,
+    '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+    '2'
+  ).connect(provider);
+
+  it('should process all subscriptions for a single sponsor wallet', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest
+      .spyOn(utils, 'retryGo')
+      .mockResolvedValue([null, { hash: ethers.utils.keccak256(ethers.utils.randomBytes(32)) }]);
+
+    const logsData = await processSponsorWallet(airnodeWallet, dapiServer, gasTarget, subscriptions, sponsorWallet);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(3);
+    expect(logsData).toEqual(
+      expect.arrayContaining([
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription1,
+        ],
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription2,
+        ],
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription3,
+        ],
+      ])
+    );
+  });
+
+  it('returns processed subscriptions with logs up until error occurs while getting function fragment from contract interface', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest
+      .spyOn(utils, 'retryGo')
+      .mockResolvedValueOnce([null, { hash: ethers.utils.keccak256(ethers.utils.randomBytes(32)) }])
+      .mockResolvedValueOnce([null, { hash: ethers.utils.keccak256(ethers.utils.randomBytes(32)) }])
+      .mockResolvedValueOnce([null, { hash: ethers.utils.keccak256(ethers.utils.randomBytes(32)) }]);
+
+    const invalidSubscription3 = { ...subscription3, fulfillFunctionId: '0xinvalid' };
+    const logsData = await processSponsorWallet(
+      airnodeWallet,
+      dapiServer,
+      gasTarget,
+      [...subscriptions, invalidSubscription3],
+      sponsorWallet
+    );
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(3);
+    expect(logsData).toEqual(
+      expect.arrayContaining([
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription1,
+        ],
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription2,
+        ],
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription3,
+        ],
+        [
+          [
+            {
+              error: expect.objectContaining({ message: expect.stringContaining('no matching function') }),
+              level: 'ERROR',
+              message: `Failed to get fulfill function`,
+            },
+          ],
+          invalidSubscription3,
+        ],
+      ])
+    );
+  });
+
+  it('returns processed subscriptions with logs up until error occurs during contract call', async () => {
+    // TODO: Mocking retryGo because it is not trivial to mock the contract object
+    const retryGoSpy = jest
+      .spyOn(utils, 'retryGo')
+      .mockResolvedValueOnce([null, { hash: ethers.utils.keccak256(ethers.utils.randomBytes(32)) }]);
+
+    const logsData = await processSponsorWallet(airnodeWallet, dapiServer, gasTarget, subscriptions, sponsorWallet);
+
+    expect(retryGoSpy).toHaveBeenCalledTimes(2);
+    expect(logsData).toEqual(
+      expect.arrayContaining([
+        [
+          [
+            {
+              level: 'INFO',
+              message: expect.stringMatching(/Tx submitted: 0x[A-Fa-f0-9]{64}/),
+            },
+          ],
+          subscription1,
+        ],
+        [
+          [
+            {
+              error: expect.any(Error),
+              level: 'ERROR',
+              message: `Failed to submit transaction using wallet ${sponsorWallet.address} with nonce ${subscription2.nonce}`,
+            },
+          ],
+          subscription2,
+        ],
+      ])
+    );
+  });
+});

--- a/src/evm/process-sponsor-wallet.ts
+++ b/src/evm/process-sponsor-wallet.ts
@@ -14,7 +14,7 @@ export const processSponsorWallet = async (
   const logs: node.LogsData<ProcessableSubscription>[] = [];
 
   // Process each subscription in serial to keep nonces in order
-  for (const subscription of subscriptions.sort((a, b) => a.nonce - b.nonce) || []) {
+  for (const subscription of subscriptions.sort((a, b) => a.nonce - b.nonce)) {
     const { id: subscriptionId, relayer, sponsor, fulfillFunctionId, nonce, apiValue } = subscription;
 
     // Encode API value

--- a/src/evm/transaction-count.test.ts
+++ b/src/evm/transaction-count.test.ts
@@ -1,0 +1,52 @@
+import { ethers } from 'ethers';
+import { getSponsorWalletAndTransactionCount } from './transaction-count';
+
+describe('getSponsorWalletAndTransactionCount', () => {
+  const airnodeWallet = ethers.Wallet.fromMnemonic(
+    'achieve climb couple wait accident symbol spy blouse reduce foil echo label'
+  );
+  const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:8545/');
+  const currentBlock = Math.floor(Date.now() / 1000);
+  const sponsor = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC';
+
+  it('should return sponsor wallet and transaction count', async () => {
+    const getTransactionCountSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getTransactionCount');
+    const transactionCount = 25;
+    getTransactionCountSpy.mockResolvedValueOnce(transactionCount);
+
+    const [logs, data] = await getSponsorWalletAndTransactionCount(airnodeWallet, provider, currentBlock, sponsor);
+
+    expect(getTransactionCountSpy).toHaveBeenCalled();
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        { level: 'INFO', message: `Sponsor wallet 0x83F...50FF transaction count: ${transactionCount}` },
+      ])
+    );
+    expect(data).toEqual(
+      expect.objectContaining({
+        sponsorWallet: expect.any(ethers.Wallet),
+        transactionCount,
+      })
+    );
+  });
+
+  it('returns null with error log if transaction count cannot be fetched', async () => {
+    const getTransactionCountSpy = jest.spyOn(ethers.providers.JsonRpcProvider.prototype, 'getTransactionCount');
+    const errorMessage = 'could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.5.3)';
+    getTransactionCountSpy.mockRejectedValueOnce(new Error(errorMessage));
+
+    const [logs, data] = await getSponsorWalletAndTransactionCount(airnodeWallet, provider, currentBlock, sponsor);
+
+    expect(getTransactionCountSpy).toHaveBeenCalled();
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          error: expect.objectContaining({ message: expect.stringContaining('could not detect network') }),
+          level: 'ERROR',
+          message: 'Failed to fetch the sponsor wallet transaction count',
+        }),
+      ])
+    );
+    expect(data).toEqual(null);
+  });
+});

--- a/src/evm/transaction-count.test.ts
+++ b/src/evm/transaction-count.test.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { getSponsorWalletAndTransactionCount } from './transaction-count';
+import { deriveSponsorWallet } from '../wallet';
 
 describe('getSponsorWalletAndTransactionCount', () => {
   const airnodeWallet = ethers.Wallet.fromMnemonic(
@@ -16,7 +17,11 @@ describe('getSponsorWalletAndTransactionCount', () => {
 
     const [logs, data] = await getSponsorWalletAndTransactionCount(airnodeWallet, provider, currentBlock, sponsor);
 
-    expect(getTransactionCountSpy).toHaveBeenCalled();
+    expect(getTransactionCountSpy).toHaveBeenNthCalledWith(
+      1,
+      deriveSponsorWallet(airnodeWallet.mnemonic.phrase, sponsor, '2').address,
+      expect.any(Number)
+    );
     expect(logs).toEqual(
       expect.arrayContaining([
         { level: 'INFO', message: `Sponsor wallet 0x83F...50FF transaction count: ${transactionCount}` },

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,0 +1,4 @@
+import { handler as pspHandler } from './psp';
+import { handler as rrpHandler } from './rrp';
+
+export { pspHandler, rrpHandler };

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -9,10 +9,12 @@ import isNil from 'lodash/isNil';
 import { keccak256 } from 'ethers/lib/utils';
 import { callApi } from '../api/call-api';
 import { loadAirkeeperConfig, loadAirnodeConfig, mergeConfigs } from '../config';
-import { checkSubscriptionCondition } from '../evm/check-conditions';
-import { initializeProvider } from '../evm/initialize-provider';
-import { processSponsorWallet } from '../evm/process-sponsor-wallet';
-import { getSponsorWalletAndTransactionCount } from '../evm/transaction-count';
+import {
+  checkSubscriptionCondition,
+  getSponsorWalletAndTransactionCount,
+  initializeProvider,
+  processSponsorWallet,
+} from '../evm';
 import {
   CheckedSubscription,
   Config,


### PR DESCRIPTION
I've added unit tests for all functions in the evm directory. I thought about adding tests to the handlers but then I realized that these are going to change a lot by the refactors planned for each one. ([rrp refactor](https://api3dao.atlassian.net/browse/BEC-238) and [psp with lambda invocation](https://api3dao.atlassian.net/browse/BEC-213)).