### PR TITLE
Refactor submitTransactions to process subscriptions sequentially

### DIFF
--- a/src/evm/process-sponsor-wallet.test.ts
+++ b/src/evm/process-sponsor-wallet.test.ts
@@ -107,7 +107,6 @@ describe('processSponsorWallet', () => {
     )
     .connect(provider);
   const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
-  const apiValuesBySubscriptionId = subscriptions.reduce((acc, s) => ({ ...acc, [s.id]: s.apiValue }), {});
 
   it('should process all subscriptions for a single sponsor wallet', async () => {
     const logsData = await processSponsorWallet(
@@ -116,8 +115,7 @@ describe('processSponsorWallet', () => {
       gasTarget,
       subscriptions,
       sponsorWallet,
-      voidSigner,
-      apiValuesBySubscriptionId
+      voidSigner
     );
 
     // Calls to conditionFunction
@@ -194,8 +192,7 @@ describe('processSponsorWallet', () => {
       gasTarget,
       [subscription1, invalidSubscription2, subscription3],
       sponsorWallet,
-      voidSigner,
-      apiValuesBySubscriptionId
+      voidSigner
     );
 
     expect(getFunctionSpy).not.toHaveBeenCalled();
@@ -262,8 +259,7 @@ describe('processSponsorWallet', () => {
       gasTarget,
       subscriptions,
       sponsorWallet,
-      voidSigner,
-      apiValuesBySubscriptionId
+      voidSigner
     );
 
     expect(getFunctionSpy).toHaveBeenCalledTimes(6);

--- a/src/evm/process-sponsor-wallet.test.ts
+++ b/src/evm/process-sponsor-wallet.test.ts
@@ -107,6 +107,7 @@ describe('processSponsorWallet', () => {
     )
     .connect(provider);
   const voidSigner = new ethers.VoidSigner(ethers.constants.AddressZero, provider);
+  const transactionCount = 0;
 
   it('should process all subscriptions for a single sponsor wallet', async () => {
     const logsData = await processSponsorWallet(
@@ -115,7 +116,8 @@ describe('processSponsorWallet', () => {
       gasTarget,
       subscriptions,
       sponsorWallet,
-      voidSigner
+      voidSigner,
+      transactionCount
     );
 
     // Calls to conditionFunction
@@ -192,7 +194,8 @@ describe('processSponsorWallet', () => {
       gasTarget,
       [subscription1, invalidSubscription2, subscription3],
       sponsorWallet,
-      voidSigner
+      voidSigner,
+      transactionCount
     );
 
     expect(getFunctionSpy).not.toHaveBeenCalled();
@@ -259,7 +262,8 @@ describe('processSponsorWallet', () => {
       gasTarget,
       subscriptions,
       sponsorWallet,
-      voidSigner
+      voidSigner,
+      transactionCount
     );
 
     expect(getFunctionSpy).toHaveBeenCalledTimes(6);

--- a/src/evm/process-sponsor-wallet.ts
+++ b/src/evm/process-sponsor-wallet.ts
@@ -12,8 +12,7 @@ export const processSponsorWallet = async (
   gasTarget: node.GasTarget,
   subscriptions: ProcessableSubscription[],
   sponsorWallet: ethers.Wallet,
-  voidSigner: ethers.VoidSigner,
-  apiValuesBySubscriptionId: { [subscriptionId: string]: ethers.BigNumber }
+  voidSigner: ethers.VoidSigner
 ): Promise<node.LogsData<ProcessableSubscription>[]> => {
   const logs: node.LogsData<ProcessableSubscription>[] = [];
   const sortedSubscriptions = subscriptions.sort((a, b) => a.nonce - b.nonce);
@@ -23,8 +22,7 @@ export const processSponsorWallet = async (
   let nextNonce = sortedSubscriptions[0].nonce;
   // Process each subscription in serial to keep nonces in order
   for (const subscription of sortedSubscriptions) {
-    const { id: subscriptionId, relayer, sponsor, fulfillFunctionId, nonce } = subscription;
-    const apiValue = apiValuesBySubscriptionId[subscription.id];
+    const { id: subscriptionId, relayer, sponsor, fulfillFunctionId, apiValue, nonce } = subscription;
 
     // Check subscription
     const [checkSubscriptionLogs, isValid] = await checkSubscriptionCondition(

--- a/src/evm/process-sponsor-wallet.ts
+++ b/src/evm/process-sponsor-wallet.ts
@@ -4,25 +4,24 @@ import { go } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import { checkSubscriptionCondition } from './check-conditions';
 import { GAS_LIMIT, TIMEOUT_MS, RETRIES } from '../constants';
-import { ProcessableSubscription } from '../types';
+import { CheckedSubscription } from '../types';
 
 export const processSponsorWallet = async (
   airnodeWallet: ethers.Wallet,
   contract: ethers.Contract,
   gasTarget: node.GasTarget,
-  subscriptions: ProcessableSubscription[],
+  subscriptions: CheckedSubscription[],
   sponsorWallet: ethers.Wallet,
-  voidSigner: ethers.VoidSigner
-): Promise<node.LogsData<ProcessableSubscription>[]> => {
-  const logs: node.LogsData<ProcessableSubscription>[] = [];
-  const sortedSubscriptions = subscriptions.sort((a, b) => a.nonce - b.nonce);
+  voidSigner: ethers.VoidSigner,
+  transactionCount: number
+): Promise<node.LogsData<CheckedSubscription>[]> => {
+  const logs: node.LogsData<CheckedSubscription>[] = [];
 
   // Keep track of nonce outside of the loop in case there is an invalid subscription and its nonce is skipped
-  //TODO: improve nonce?
-  let nextNonce = sortedSubscriptions[0].nonce;
+  let nextNonce = transactionCount;
   // Process each subscription in serial to keep nonces in order
-  for (const subscription of sortedSubscriptions) {
-    const { id: subscriptionId, relayer, sponsor, fulfillFunctionId, apiValue, nonce } = subscription;
+  for (const subscription of subscriptions) {
+    const { id: subscriptionId, relayer, sponsor, fulfillFunctionId, apiValue } = subscription;
 
     // Check subscription
     const [checkSubscriptionLogs, isValid] = await checkSubscriptionCondition(
@@ -32,7 +31,8 @@ export const processSponsorWallet = async (
       voidSigner
     );
     logs.push([checkSubscriptionLogs, subscription]);
-    // Skip processing if if subscription is invalid
+
+    // Skip processing if the subscription is invalid
     if (!isValid) {
       continue;
     }
@@ -64,6 +64,7 @@ export const processSponsorWallet = async (
       logs.push([[log], subscription]);
       continue;
     }
+    const nonce = nextNonce++;
     const tx = await go<ethers.ContractTransaction, Error>(
       () =>
         contract
@@ -79,7 +80,7 @@ export const processSponsorWallet = async (
             {
               gasLimit: GAS_LIMIT,
               ...gasTarget,
-              nonce: nextNonce++,
+              nonce,
             }
           ),
       { timeoutMs: TIMEOUT_MS, retries: RETRIES }

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -275,7 +275,7 @@ const processSubscriptions = async (
       return;
     }
 
-    const sponsorWallet = walletData.sponsorWallet;
+    const { sponsorWallet, transactionCount } = walletData;
 
     const sponsorWalletLogOptions = buildLogOptions(
       'additional',
@@ -284,21 +284,16 @@ const processSubscriptions = async (
     );
     utils.logger.logPending(transactionCountLogs, sponsorWalletLogOptions);
 
-    // Get subscriptions for the current sponsorAddress and assign nonces
-    const subscriptionsWithNonce = subscriptions.map((subscription, idx) => ({
-      ...subscription,
-      nonce: walletData.transactionCount + idx,
-    }));
-
     utils.logger.info(`Processing ${subscriptions.length} subscription(s)`, sponsorWalletLogOptions);
 
     const logs = await processSponsorWallet(
       airnodeWallet,
       contracts['DapiServer'],
       gasTarget,
-      subscriptionsWithNonce,
+      subscriptions,
       sponsorWallet,
-      voidSigner
+      voidSigner,
+      transactionCount
     );
 
     logs.forEach(([logs, data]) => {

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -345,7 +345,7 @@ const submitTransactions = async (state: State) => {
       // Group filtered subscriptions by sponsorAddress
       const subscriptionsBySponsor = groupBy(chainSubscriptions, 'sponsor');
 
-      // Collect subscriptions for each provider
+      // Collect subscriptions for each provider + sponsor pair
       const subscriptionGroup = Object.entries(subscriptionsBySponsor).map(([sponsorAddress, subscriptions]) => ({
         sponsorAddress: sponsorAddress,
         providerState: providerState,

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -249,7 +249,7 @@ const initializeProviders = async (state: State): Promise<State> => {
 };
 
 const processSubscriptions = async (
-  providerSubscriptions: {
+  providerSponsorSubscriptions: {
     sponsorAddress: string;
     providerState: ProviderState<EVMProviderState>;
     subscriptions: Id<CheckedSubscription>[];

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -322,7 +322,7 @@ const submitTransactions = async (state: State) => {
 
   const subscriptions = groupedSubscriptions.flatMap((s) => s.subscriptions);
 
-  const providerSubscriptions = providerStates.reduce(
+  const providerSponsorSubscriptions = providerStates.reduce(
     (
       acc: {
         sponsorAddress: string;

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -18,6 +18,7 @@ import {
   ProviderState,
   State,
   CheckedSubscription,
+  ProviderSponsorSubscriptions,
 } from '../types';
 import { TIMEOUT_MS, RETRIES } from '../constants';
 import { Subscription } from '../validator';
@@ -249,14 +250,10 @@ const initializeProviders = async (state: State): Promise<State> => {
 };
 
 const processSubscriptions = async (
-  providerSponsorSubscriptions: {
-    sponsorAddress: string;
-    providerState: ProviderState<EVMProviderState>;
-    subscriptions: Id<CheckedSubscription>[];
-  }[],
+  providerSponsorSubscriptions: ProviderSponsorSubscriptions[],
   baseLogOptions: utils.LogOptions
 ) => {
-  const providerSponsorPromises = providerSubscriptions.map(async (subscriptionGroup) => {
+  const providerSponsorPromises = providerSponsorSubscriptions.map(async (subscriptionGroup) => {
     const { sponsorAddress, providerState, subscriptions } = subscriptionGroup;
     const { airnodeWallet, providerName, chainId, provider, contracts, voidSigner, currentBlock, gasTarget } =
       providerState;
@@ -314,7 +311,7 @@ const processSubscriptions = async (
     });
   });
 
-  await Promise.all(providerPromises);
+  await Promise.all(providerSponsorPromises);
 };
 
 const submitTransactions = async (state: State) => {
@@ -358,7 +355,7 @@ const submitTransactions = async (state: State) => {
   );
 
   // TODO: start new lambdas for each providerSubscriptions array element
-  await processSubscriptions(providerSubscriptions, baseLogOptions);
+  await processSubscriptions(providerSponsorSubscriptions, baseLogOptions);
 };
 
 const updateBeacon = async (config: Config) => {

--- a/src/handlers/psp.ts
+++ b/src/handlers/psp.ts
@@ -256,7 +256,7 @@ const processSubscriptions = async (
   }[],
   baseLogOptions: utils.LogOptions
 ) => {
-  const providerPromises = providerSubscriptions.map(async (subscriptionGroup) => {
+  const providerSponsorPromises = providerSubscriptions.map(async (subscriptionGroup) => {
     const { sponsorAddress, providerState, subscriptions } = subscriptionGroup;
     const { airnodeWallet, providerName, chainId, provider, contracts, voidSigner, currentBlock, gasTarget } =
       providerState;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,8 @@ export interface SponsorWalletTransactionCount {
   transactionCount: number;
 }
 
-export interface SponsorWalletWithSubscriptions {
-  subscriptions: ProcessableSubscription[];
-  sponsorWallet: ethers.Wallet;
+export interface ProviderSponsorSubscriptions {
+  sponsorAddress: string;
+  providerState: ProviderState<EVMProviderState>;
+  subscriptions: Id<CheckedSubscription>[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,10 +74,6 @@ export interface CheckedSubscription extends Id<Subscription> {
   apiValue: ethers.BigNumber;
 }
 
-export interface ProcessableSubscription extends Id<CheckedSubscription> {
-  nonce: number;
-}
-
 export interface SponsorWalletTransactionCount {
   sponsorWallet: ethers.Wallet;
   transactionCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export interface CheckedSubscription extends Id<Subscription> {
   apiValue: ethers.BigNumber;
 }
 
-export interface ProcessableSubscription extends CheckedSubscription {
+export interface ProcessableSubscription extends Id<Subscription> {
   nonce: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export interface CheckedSubscription extends Id<Subscription> {
   apiValue: ethers.BigNumber;
 }
 
-export interface ProcessableSubscription extends Id<Subscription> {
+export interface ProcessableSubscription extends Id<CheckedSubscription> {
   nonce: number;
 }
 


### PR DESCRIPTION
This moves the subscription checking, wallet functions and processing to be done for each sponsorAddress group.
Opening this as draft to get some help on how to proceed.

The old flow was:
1. Get all subscriptions from **airkeeper.json**
2. Filter subscriptions by chain ID (i.e. chain provider)
3. Check that all filtered subscriptions pass the condition check
4. Group subscriptions by sponsor wallet address
5. Start fulfilling subscriptions for each sponsor wallet-group in parallel

The new intended flow:
1. Get all subscriptions from **airkeeper.json**
2. Filter subscriptions by chain provider
3. Group subscriptions by **sponsorAddress**
4. Start processing the subscriptions for each **sponsorAddress** sequentially
   4.1. `getSponsorWalletAndTransactionCount` 
   4.2. if valid wallet data `processSponsorWallet`
      4.2.1. `checkSubscriptionCondition`
      4.2.2. if valid subscription `fulfillPspBeaconUpdate`
5. Process subscriptions for each provider 

