### PR TITLE
Bec254 improve api calls

### DIFF
--- a/src/api/call-api.test.ts
+++ b/src/api/call-api.test.ts
@@ -21,6 +21,7 @@ describe('callApi', () => {
     airkeeperConfig
   );
   const airnodeAddress = airkeeperConfig.airnodeAddress;
+  const airnodeXpub = airkeeperConfig.airnodeXpub;
   if (airkeeperConfig.airnodeAddress && airkeeperConfig.airnodeAddress !== airnodeAddress) {
     throw new Error(`xpub does not belong to Airnode: ${airnodeAddress}`);
   }
@@ -33,14 +34,23 @@ describe('callApi', () => {
     const spy = jest.spyOn(adapter, 'buildAndExecuteRequest') as any;
 
     const apiResponse = { data: { success: true, result: '723.392028' } };
-    spy.mockResolvedValueOnce(apiResponse);
+    spy.mockResolvedValue(apiResponse);
 
-    const [logs, res] = await callApi(config, endpoint, apiCallParameters);
+    let [logs, res] = await callApi(config, endpoint, apiCallParameters);
 
-    expect(logs).toHaveLength(0);
+    expect(logs).toHaveLength(1);
+    expect(logs).toEqual(expect.arrayContaining([{ level: 'DEBUG', message: 'API value: 723392028' }]));
     expect(res).toBeDefined();
     expect(res).toEqual(ethers.BigNumber.from(723392028));
     expect(spy).toHaveBeenCalledTimes(1);
+
+    [logs, res] = await callApi({ ...config, airnodeXpub }, endpoint, apiCallParameters);
+
+    expect(logs).toHaveLength(1);
+    expect(logs).toEqual(expect.arrayContaining([{ level: 'DEBUG', message: 'API value: 723392028' }]));
+    expect(res).toBeDefined();
+    expect(res).toEqual(ethers.BigNumber.from(723392028));
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it("returns null if reserved parameter '_type' is missing", async () => {

--- a/src/api/call-api.ts
+++ b/src/api/call-api.ts
@@ -5,12 +5,12 @@ import { Config } from '../types';
 import { Endpoint } from '../validator';
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
-// const maybeFail = (successProbability: number, result: string, error: Error) =>
-//   new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
+const maybeFail = (successProbability: number, result: string, error: Error) =>
+  new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
 
-// const maybeFailingOperation = async () => {
-//   return maybeFail(0.1, 'API call succeeded!', new Error('API call failed!'));
-// };
+const maybeFailingOperation = async () => {
+  return maybeFail(0.1, '---------> API call SUCCEEDED!', new Error('---------> API call FAILED!'));
+};
 
 export const callApi = async (
   config: Config,
@@ -19,19 +19,19 @@ export const callApi = async (
 ): Promise<node.LogsData<ethers.BigNumber | null>> => {
   console.log('---------> Attempting to fetch:', parameters['from']);
   console.log('---------> timestamp: ', Date.now().toString());
-  if (parameters['from'] === 'API3') {
-    const min = 75;
-    const max = 125;
-    const sleepMs = Math.floor(Math.random() * (max - min + 1)) + min;
-    console.log('---------> sleepMs', sleepMs);
-    await wait(sleepMs);
+  if (parameters['from'] !== 'API3') {
+    // const min = 75;
+    // const max = 125;
+    // const sleepMs = Math.floor(Math.random() * (max - min + 1)) + min;
+    // console.log('---------> sleepMs', sleepMs);
+    // await wait(sleepMs);
 
-    // await wait(1100);
+    await wait(1001);
 
     console.log('---------> ABOUT TO FAIL:', Date.now().toString());
-    //console.log('---------> RESULT:', await maybeFailingOperation());
+    console.log('---------> RESULT:', await maybeFailingOperation());
     // return Promise.reject(new Error('Error from API3'));
-    throw new Error('Error from API3');
+    // throw new Error('Error from API3');
   }
 
   // Note: airnodeAddress, endpointId, id are not used in callApi verification, but are required by the node.AggregatedApiCall type

--- a/src/api/call-api.ts
+++ b/src/api/call-api.ts
@@ -4,36 +4,11 @@ import { ethers } from 'ethers';
 import { Config } from '../types';
 import { Endpoint } from '../validator';
 
-const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
-const maybeFail = (successProbability: number, result: string, error: Error) =>
-  new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
-
-const maybeFailingOperation = async () => {
-  return maybeFail(0.1, '---------> API call SUCCEEDED!', new Error('---------> API call FAILED!'));
-};
-
 export const callApi = async (
   config: Config,
   endpoint: Endpoint,
   parameters: node.ApiCallParameters
 ): Promise<node.LogsData<ethers.BigNumber | null>> => {
-  console.log('---------> Attempting to fetch:', parameters['from']);
-  console.log('---------> timestamp: ', Date.now().toString());
-  if (parameters['from'] !== 'API3') {
-    // const min = 75;
-    // const max = 125;
-    // const sleepMs = Math.floor(Math.random() * (max - min + 1)) + min;
-    // console.log('---------> sleepMs', sleepMs);
-    // await wait(sleepMs);
-
-    await wait(1001);
-
-    console.log('---------> ABOUT TO FAIL:', Date.now().toString());
-    console.log('---------> RESULT:', await maybeFailingOperation());
-    // return Promise.reject(new Error('Error from API3'));
-    // throw new Error('Error from API3');
-  }
-
   // Note: airnodeAddress, endpointId, id are not used in callApi verification, but are required by the node.AggregatedApiCall type
   const airnodeHDNode = ethers.utils.HDNode.fromMnemonic(config.nodeSettings.airnodeWalletMnemonic);
   const airnodeAddress = (
@@ -55,7 +30,6 @@ export const callApi = async (
   }
 
   const parsedData = JSON.parse(apiCallResponse.value);
-  // const decodedValue = ethers.utils.defaultAbiCoder.decode(['uint256'], parsedData.encodedValue);
   const [apiValue] = parsedData.values;
   const messageApiValue = `API value: ${apiValue}`;
   const logApiValue = utils.logger.pend('DEBUG', messageApiValue);

--- a/src/api/call-api.ts
+++ b/src/api/call-api.ts
@@ -5,12 +5,12 @@ import { Config } from '../types';
 import { Endpoint } from '../validator';
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
-const maybeFail = (successProbability: number, result: string, error: Error) =>
-  new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
+// const maybeFail = (successProbability: number, result: string, error: Error) =>
+//   new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
 
-const maybeFailingOperation = async () => {
-  return maybeFail(0.1, 'API call succeeded!', new Error('API call failed!'));
-};
+// const maybeFailingOperation = async () => {
+//   return maybeFail(0.1, 'API call succeeded!', new Error('API call failed!'));
+// };
 
 export const callApi = async (
   config: Config,
@@ -26,12 +26,12 @@ export const callApi = async (
     console.log('---------> sleepMs', sleepMs);
     await wait(sleepMs);
 
-    //await wait(1100);
+    // await wait(1100);
 
     console.log('---------> ABOUT TO FAIL:', Date.now().toString());
-    console.log('---------> RESULT:', await maybeFailingOperation());
+    //console.log('---------> RESULT:', await maybeFailingOperation());
     // return Promise.reject(new Error('Error from API3'));
-    // throw new Error('Error from API3');
+    throw new Error('Error from API3');
   }
 
   // Note: airnodeAddress, endpointId, id are not used in callApi verification, but are required by the node.AggregatedApiCall type

--- a/src/api/call-api.ts
+++ b/src/api/call-api.ts
@@ -4,11 +4,36 @@ import { ethers } from 'ethers';
 import { Config } from '../types';
 import { Endpoint } from '../validator';
 
+const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+const maybeFail = (successProbability: number, result: string, error: Error) =>
+  new Promise((res, rej) => (Math.random() < successProbability ? res(result) : rej(error)));
+
+const maybeFailingOperation = async () => {
+  return maybeFail(0.1, 'API call succeeded!', new Error('API call failed!'));
+};
+
 export const callApi = async (
   config: Config,
   endpoint: Endpoint,
   parameters: node.ApiCallParameters
 ): Promise<node.LogsData<ethers.BigNumber | null>> => {
+  console.log('---------> Attempting to fetch:', parameters['from']);
+  console.log('---------> timestamp: ', Date.now().toString());
+  if (parameters['from'] === 'API3') {
+    const min = 75;
+    const max = 125;
+    const sleepMs = Math.floor(Math.random() * (max - min + 1)) + min;
+    console.log('---------> sleepMs', sleepMs);
+    await wait(sleepMs);
+
+    //await wait(1100);
+
+    console.log('---------> ABOUT TO FAIL:', Date.now().toString());
+    console.log('---------> RESULT:', await maybeFailingOperation());
+    // return Promise.reject(new Error('Error from API3'));
+    // throw new Error('Error from API3');
+  }
+
   // Note: airnodeAddress, endpointId, id are not used in callApi verification, but are required by the node.AggregatedApiCall type
   const airnodeHDNode = ethers.utils.HDNode.fromMnemonic(config.nodeSettings.airnodeWalletMnemonic);
   const airnodeAddress = (
@@ -30,6 +55,9 @@ export const callApi = async (
   }
 
   const parsedData = JSON.parse(apiCallResponse.value);
-  const apiValue = ethers.BigNumber.from(parsedData.values[0].toString());
-  return [logs, apiValue];
+  // const decodedValue = ethers.utils.defaultAbiCoder.decode(['uint256'], parsedData.encodedValue);
+  const [apiValue] = parsedData.values;
+  const messageApiValue = `API value: ${apiValue}`;
+  const logApiValue = utils.logger.pend('DEBUG', messageApiValue);
+  return [[...logs, logApiValue], ethers.BigNumber.from(apiValue)];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,3 +84,9 @@ export interface ProviderSponsorSubscriptions {
   providerState: ProviderState<EVMProviderState>;
   subscriptions: Id<CheckedSubscription>[];
 }
+
+export type CallApiResult = node.LogsData<{
+  templateId: string;
+  apiValue: ethers.BigNumber | null;
+  subscriptions: Id<Subscription>[];
+}>;


### PR DESCRIPTION
These changes will allow Airkeeper to:
1. retry each individual API call indefinitely on failure with a random backoff or until a 10 sec timeout is reached
2. all API calls will be triggered in parallel with a shared timeout of 40 sec
3. each API call will store its result in a shared variable in memory and Airkeeper will try to continue processing with as many results were retrieved from API.

Note 1: when timeouts are reached, background running processes are not killed there I added those boolean flags to avoid having any unhandled exception when there's a timeout.

Note: I ran into issue when trying to accomplish the same using promise-utils package `go()` function and since this function needs to be changed to support more AttemptOptions params then I thought it would be good to work on those changes then publish a new promise-utils package and finally switch to using promise-utils in here.