### PR TITLE
Fix sls variables, dockerfile install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ RUN git clone --single-branch --branch ${branch} ${repository} ${buildDir}
 # Production dependencies
 FROM source${build} AS deps
 
-RUN yarn install --production --no-optional --ignore-scripts
+RUN yarn install
+# TODO add back after Airnode 0.6 is released 
+# --production --no-optional --ignore-scripts
 
 FROM source${build} AS build
 
@@ -52,7 +54,7 @@ LABEL application=${name} \
 COPY --from=deps ${buildDir}/node_modules ./node_modules
 COPY --from=build ${packageDir} .
 
-    # Create Airkeeper user
+# Create Airkeeper user
 RUN adduser -h ${appDir} -s /bin/false -S -D -H ${name} && \
     chown -R ${name} ${appDir} && \
     # Install serverless

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ docker build . -t api3/airkeeper
 
 ### Deployment
 
-The `deploy` command will create a new AWS lambda function set and a new AWS cloud scheduler.
+The `deploy` command will create a new AWS lambda function set and a new AWS cloud scheduler. The serverless `stage` and
+`region` variables are set with the following priority order:
+
+1. CLI options
+2. `aws.env` file
+3. default values `stage`: 'dev' and `region`: 'us-east-1'
 
 ```sh
 docker run -it --rm \

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,8 +2,8 @@ service: airkeeper
 
 provider:
   name: aws
-  region: ${env:REGION, 'us-east-1'}
-  stage: ${env:STAGE, 'dev'}
+  region: ${opt:region, env:REGION, 'us-east-1'}
+  stage: ${opt:stage, env:STAGE, 'dev'}
   runtime: nodejs14.x
   memorySize: 512
   logRetentionInDays: 14
@@ -12,7 +12,7 @@ provider:
     - Effect: 'Allow'
       Action:
         - 'lambda:InvokeFunction'
-      Resource: 'arn:aws:lambda:${self:provider.region}:${AWS::AccountId}:function:${self:service}-${self:provider.stage}-process-subscriptions'
+      Resource: !Sub 'arn:aws:lambda:${self:provider.region}:${AWS::AccountId}:function:${self:service}-${self:provider.stage}-process-subscriptions'
 
 package:
   patterns:


### PR DESCRIPTION
This fixes setting the serverless `stage` and `region`  variables with the CLI and fixes the dockerfile `yarn install` script to work with the airnode `postinstall` script.