### PR TITLE
Adds reserved concurrency to lambda functions via serveless framework

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,7 @@ functions:
     timeout: 60
     events:
       - schedule: rate(1 minute)
+    reservedConcurrency: 1
   psp-beacon-update:
     handler: dist/handlers/psp.handler
     environment:
@@ -32,6 +33,8 @@ functions:
     timeout: 60
     events:
       - schedule: rate(1 minute)
+    reservedConcurrency: 1
   process-subscriptions:
     handler: dist/handlers/process-subscriptions.handler
     timeout: 15
+    reservedConcurrency: 100


### PR DESCRIPTION
Closes #67 

Tested by deploying all 3 functions to AWS and verified that the concurrency was set.